### PR TITLE
Fix typos, phrasing, HTTP API example syntax 

### DIFF
--- a/site/mirabelle/content/_index.md
+++ b/site/mirabelle/content/_index.md
@@ -2,23 +2,23 @@
 
 Mirabelle is a stream processing engine which can be used to aggregate events, metrics and logs.
 
-Its powerful and extensible DSL allows you to define computations on a stream of data. Mirabelle offers natively a lot of functions (time windows, mathematical operations, transforming data, relabelling...) which can be easily combined according to your needs.
+Its powerful and extensible DSL allows you to define computations on a stream of data. Mirabelle offers natively a lot of functions (time windows, mathematical operations, transforming data, relabeling, etc.) which can be easily combined according to your needs.
 
 ![Mirabelle](img/mirabelle_presentation.png)
 
-Mirabelle can also route events to external systems (timeserie databases, logging systems, cloud monitoring services...), fire alerts (Pagerduty), write data into files...
+Mirabelle can also route events to external systems (timeseries databases, logging systems, cloud monitoring services, etc.), fire alerts (e.g. to Pagerduty), write data into files and more.
 
 It also implements a publish-subscribe system, which allows you to see in real time (through Websockets) events flowing into streams.
 
-Mirabelle is in alpha, but I'm eager to receive feedbacks
+Mirabelle is currently in alpha, but I'm eager to receive feedback.
 
 ## Fully compatible with Riemann
 
-Mirabelle is heavily inspired by [Riemann](http://riemann.io/). Actually, part of the Mirabelle codebase (some streams and the TCP server implementation for example) was imported from Riemann (these parts are mentionned in the codebase).
+Mirabelle is heavily inspired by [Riemann](https://riemann.io/). Actually, part of the Mirabelle codebase (some streams and the TCP server implementation for example) was imported from Riemann (these parts are mentioned in the codebase).
 
 I would like to thank all Riemann maintainers and contributors for this amazing tool.
 
-Mirabelle use the same protocol than Riemann. It means all Riemann tooling and integrations should work seamlessy with Mirabelle (which also added a lot of new features).
+Mirabelle use the same protocol than Riemann. It means all Riemann tooling and integrations should work seamlessly with Mirabelle (which also added a lot of new features).
 
 Like in Riemann, Mirabelle provides an index which can be queried (and on which you can subscribe) in order to explore your system state.
 
@@ -38,9 +38,9 @@ You can even use Mirabelle to play and explore with historical data. You could h
 
 ## Stream example, with unit tests
 
-Let's say a web application is pushing the duration (in seconds) of the http requests it receives. This metric could be modelised using this Mirabelle event
+Let's say a web application is pushing the duration (in seconds) of the HTTP requests it receives. This metric could be modeled using this Mirabelle event
 
-```
+```clojure
 {:host "my-server"
  :service "http_request_duration_seconds"
  :application "my-web-app"
@@ -49,7 +49,7 @@ Let's say a web application is pushing the duration (in seconds) of the http req
  :metric 0.5}
 ```
 
-You could write a Mirabelle stream which will compute on the fly the quantiles for this metric. In this example, Mirabelle will split the received events into 60 seconds windows, then compute the percentiles, set the event `:state` to "critical" and send an alert to Pagerduty if the `0.99` quantiles is greater than 1 seocnd.
+You could write a Mirabelle stream which will compute on the fly the quantiles for this metric. In this example, Mirabelle will split the received events into 60 seconds windows, then compute the percentiles, set the event `:state` to "critical" and send an alert to Pagerduty if the `0.99` quantiles is greater than 1 second.
 
 ```clojure
 (streams
@@ -87,7 +87,7 @@ A test for this stream would be:
 
 In this test, we inject into the `:percentiles` stream three events, and we verify that the tap named `:alert` contains the expected alert (the `0.99` quantile is greater than 1) generated for these events.
 
-Thanks to Clojure datastructures, these is *no side effects between streams and actions*. It's OK to modify events in parallel (in multiple threads) and to have multiple branches per stream. You can even pass events between streams (like described [here](todo)). You are free to organize streams and how they communicate between each other exactly how you want to, the tool and its DSL will not limit you on than.
+Thanks to Clojure datastructures, there is *no side effects between streams and actions*. It's OK to modify events in parallel (in multiple threads) and to have multiple branches per stream. You can even pass events between streams (like described [here](todo)). You are free to organize streams and how they communicate between each other exactly how you want to; the tool and its DSL will not limit you.
 
 Here is a more complete and commented example, with multiple actions performed in one stream:
 

--- a/site/mirabelle/content/api/_index.md
+++ b/site/mirabelle/content/api/_index.md
@@ -6,7 +6,7 @@ disableToc: false
 
 ## Health
 
-- **GET** /healthz or /health
+- **GET** `/healthz` or `/health`
 
 ---
 
@@ -18,7 +18,7 @@ curl localhost:5558/healthz
 
 ## Metrics
 
-- **GET** /metrics
+- **GET** `/metrics`
 
 Mirabelle metrics are returned as Prometheus format.
 
@@ -26,7 +26,7 @@ Mirabelle metrics are returned as Prometheus format.
 
 ### Add a stream
 
-- **POST** api/v1/stream/<stream-name>
+- **POST** `/api/v1/stream/<stream-name>`
 
 The body is a json string like `{"config": "<stream-config>"}`.
 
@@ -44,7 +44,7 @@ curl -H "Content-Type: application/json" -X POST --data  '{"config": "ezphY3Rpb2
 
 ### List streams
 
-- **GET** api/v1/stream/
+- **GET** `/api/v1/stream/`
 
 List all streams configured in Mirabelle.
 
@@ -57,7 +57,7 @@ List all streams configured in Mirabelle.
 
 ### Get a stream
 
-- **GET** api/v1/stream/<stream-name>
+- **GET** `/api/v1/stream/<stream-name>`
 
 Get a stream configuration and the time of its index.
 
@@ -69,7 +69,7 @@ curl localhost:5558/api/v1/stream/trololo
 
 ### Remove a stream
 
-- **DELETE** api/v1/stream/<stream-name>
+- **DELETE** `/api/v1/stream/<stream-name>`
 
 Delete a stream by name.
 
@@ -83,7 +83,7 @@ curl -X DELETE localhost:5558/api/v1/stream/trololo
 
 ### Push an event
 
-- **PUT** api/v1/stream/<stream-name>
+- **PUT** `/api/v1/stream/<stream-name>`
 
 Push an event to the specified stream.
 
@@ -97,7 +97,7 @@ curl -H "Content-Type: application/json" -X PUT --data '{"event": {"service": "f
 
 ### Query the index
 
-- **GET** api/v1/index/<steam-name>/search
+- **GET** `/api/v1/index/<steam-name>/search`
 
 Returns events matching the query for the index of the stream `<stream-name>`. The query passed in the body should be a [where query](/howto/stream/#filtering-events).
 
@@ -111,7 +111,9 @@ curl -H "Content-Type: application/json" -X POST --data '{"query": "Wzo9IDpzZXJ2
 
 ### Get the default index current time
 
-get the current time for the default index
+- **GET** `/api/v1/current-time`
+
+Get the current time for the default index.
 
 ---
 

--- a/site/mirabelle/content/howto/build/_index.md
+++ b/site/mirabelle/content/howto/build/_index.md
@@ -11,7 +11,7 @@ In order to build Mirabelle, you need to install:
 - [Leiningen](https://leiningen.org/), the Clojure build tool.
 - Java. Mirabelle is tested under Java 11 (LTS).
 
-Then, close the Mirabelle [Git repository](https://github.com/mcorbin/mirabelle). You can now build the project with `lein uberjar`.
+Then, clone the Mirabelle [Git repository](https://github.com/mcorbin/mirabelle). You can now build the project with `lein uberjar`.
 
 The resulting jar will be in `target/uberjar/mirabelle-<version>-standalone.jar`
 
@@ -58,4 +58,3 @@ mcorbin/mirabelle:v0.1.0
 ## Using Leiningen
 
 `lein run` should work. The configuration used is the file `dev/resources/config.edn`. You should replace the path in this file by your own paths.
-

--- a/site/mirabelle/content/production/_index.md
+++ b/site/mirabelle/content/production/_index.md
@@ -4,7 +4,7 @@ weight: 2
 chapter: false
 ---
 
-*Warning*: Mirabelle is for now not ready for production, it's still an alpha software.
+*Warning*: Mirabelle is for now not ready for production, it's still alpha software.
 
 Is section is about the Mirabelle streams guarantees, Mirabelle use cases, fault tolerance and the metrics exposed by Mirabelle.
 
@@ -47,11 +47,11 @@ It means you can have streams for various use cases. For example, you could have
 
 You can also perform continuous queries using Mirabelle. Indeed, if you compute things on the fly using events coming from multiple hosts (like, time windows on events coming from various hosts or services), Mirabelle may only be able to do approximation on the computations.
 
-As I said before, Mirabelle streams use the events time for their clocks, so "old" events could be removed from computations. But it's OK, because there are ways of mitigating that (accept events un actions until they are not expired, so if your events have a TTL of 60 seconds, it's OK if they arrive a few seconds late). I also like the Riemann philosophy which is `mostly correct information right now is more useful, than totally correct information only available once the failure is over`.
+As previously mentioned, Mirabelle streams use the events time for their clocks, so "old" events could be removed from computations. But it's OK, because there are ways of mitigating that (accept events and actions until they are not expired, so if your events have a TTL of 60 seconds, it's OK if they arrive a few seconds late). I also like the Riemann philosophy which is `mostly correct information right now is more useful, than totally correct information only available once the failure is over`.
 
 But what if you want totally correct information ? In that case, you can just:
 
-- Forward all raw events to an external system (timeserie database for example)
+- Forward all raw events to an external system (timeseries database for example)
 - Reinject them a bit later, sorted, into Mirabelle. It could be a dedicated Mirabelle instance, or a dedicated stream on your first instance. In this mode, you should have totally correct computations.
 
 You can even use Mirabelle to play with old data, like "let's reinject all data from 2 weeks ago into Mirabelle in order to compute some statistics, or detect weird things over time" !
@@ -66,7 +66,7 @@ You can always use continuous queries (and replay events if needed) in order to 
 
 You can also put a thing like [Kafka](https://kafka.apache.org/) in front of Riemann (or even push Riemann metrics to Kafka).
 
-I will soon add the possibility to forward events between Mirabelle instances, and I will also build a proxy which will be able to forward events to various Mirabelle instances based on some criterias/algorithms (duplicates to everyone, consistent hashing...).
+I will soon add the possibility to forward events between Mirabelle instances, and I will also build a proxy which will be able to forward events to various Mirabelle instances based on some criteria/algorithms (duplicates to everyone, consistent hashing...).
 
 ## Metrics
 
@@ -93,7 +93,7 @@ Mirabelle exposes a `/metrics` endpoint. For example, a lot of JVM internal metr
 
 ### Async queues
 
-For each async queues, you have these metrics (the `executor` label is the async quee name):
+For each async queues, you have these metrics (the `executor` label is the async queue name):
 
 - `executor_queue_remaining_capacity`: The remaining capacity of the executor queue, example `executor_queue_remaining_capacity{executor="thread-pool",} 10000.0`.
 - `executor_queue_tasks`: the accepted and completed tasks in the executor, for example `executor_queue_tasks{executor="thread-pool",state="accepted",}` or `executor_queue_tasks{executor="thread-pool",state="completed",}`

--- a/site/mirabelle/content/riemann-diff/_index.md
+++ b/site/mirabelle/content/riemann-diff/_index.md
@@ -30,7 +30,7 @@ When you send an event to Mirabelle, you can specify the `stream` attribute in o
 
 Riemann mostly works on the `:host` and `:service` fields. it's common to encode "dimensions" in `:service`.
 
-For example, you could have in Riemann a service named `http_requests_duration_prod_p99`. In mirabelle, you would modelize this event like this: `{:service "http_requests_duration" :environment "prod" :quantile "0.99"}`
+For example, you could have in Riemann a service named `http_requests_duration_prod_p99`. In Mirabelle, you would model this event like this: `{:service "http_requests_duration" :environment "prod" :quantile "0.99"}`
 
 A lot of Riemann streams/actions (`index`, `coalesce`...) were rewritten. You can now provide for each action on which keys it should work instead to have to manipulate complex `:service` names.
 
@@ -52,7 +52,7 @@ Mirabelle does not use the Riemann query language to query the index. Instead, i
 
 ## Clear distinctions streams and I/O
 
-Streams and I/O are configured separatly, and streams references I/O. These components do not have the same lifecycle, and handling I/O is less error prone in Mirabelle, especially during reloads.
+Streams and I/O are configured separately, and streams references I/O. These components do not have the same lifecycle, and handling I/O is less error prone in Mirabelle, especially during reloads.
 
 ## Hot reload
 


### PR DESCRIPTION
Found Mirabelle through [your thread](https://www.reddit.com/r/Clojure/comments/nubrnd/mirabelle_a_stream_processing_tool_for_monitoring/) in [/r/clojure](https://www.reddit.com/r/Clojure/) and it seems great -- thanks! The documentation had a few typos and instances of awkward phrasing which I've fixed in this PR.

In the HTTP API documentation the `<value>` placeholders weren't in backticks and were interpreted as HTML. I've taken the liberty of wrapping these in backticks.