### PR TITLE
Fix format string to work with all numbers.

### DIFF
--- a/src/clojure/mirabelle/action.clj
+++ b/src/clojure/mirabelle/action.clj
@@ -1315,7 +1315,7 @@
   [n & children]
   (mspec/valid-action? ::over [n])
   {:action :over
-   :description {:message (format "Keep events with metrics greater than %d" n)}
+   :description {:message (format "Keep events with metrics greater than %s" n)}
    :params [n]
    :children children})
 
@@ -1341,7 +1341,7 @@
   [n & children]
   (mspec/valid-action? ::under [n])
   {:action :under
-   :description {:message (format "Keep events with metrics under than %d" n)}
+   :description {:message (format "Keep events with metrics under %s" n)}
    :params [n]
    :children children})
 


### PR DESCRIPTION
Compilation failed when using certain parameters.
For instance when using `over 1.5` it fails, while it doesn't for 15.

Maybe we need to do the same on other formats

Fixes #23